### PR TITLE
Remove require_relative

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,5 +1,4 @@
 require_relative 'config/environment'
-require_relative 'models/textanalyzer.rb'
 
 class App < Sinatra::Base
 


### PR DESCRIPTION
The  `require_relative 'models/textanalyzer.rb'` line is part of the activity and should not be included here. Also, this makes the app not run before the `/models/textanalyzer.rb` file is created.