### PR TITLE
fix submitting form

### DIFF
--- a/spec/integrating_models_sinatra_walkthrough_spec.rb
+++ b/spec/integrating_models_sinatra_walkthrough_spec.rb
@@ -19,7 +19,7 @@ describe App do
       visit '/'
 
       fill_in(:user_text, :with => "Green Eggs and Ham")
-      click_button "submit"
+      find('input[type="submit"]').click
       expect(page).to have_text("Number of Words:4")
       expect(page).to have_text("Vowels:4")
       expect(page).to have_text("Consonants:8")


### PR DESCRIPTION
The `click_button "submit"` does not work with a form. It expects an HTML button tag, but our button is generated with `<input type="submit=">` in `/views/index.erb`. 

The old code leads to 
```
Failure/Error: click_button 'submit'
Capybara::ElementNotFound:
Unable to find button "submit"
```